### PR TITLE
Add GitHub Pages PR preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,44 @@
+name: PR Preview
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run export
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: out
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
+
   // Disable hydration warnings in development for browser extension compatibility
   webpack: (config, { dev }) => {
     if (dev) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "export": "next export",
     "start": "next start",
     "lint": "next lint",
     "test:integration": "node tests/e2b-integration.test.js",


### PR DESCRIPTION
## Summary
- export Next.js app for static hosting
- add script for static export
- deploy PR previews to GitHub Pages via Actions

## Testing
- `npm run lint`
- `npm run test:all` *(fails: Cannot find module '/workspace/terminal-jarvis-frankenstein/tests/e2b-integration.test.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b9838acf408333b5bd6a6b9fff5fc5